### PR TITLE
Update Dockerfile to Python 3.12 to install latest version of yamllint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache bash ca-certificates curl git jq openssh


### PR DESCRIPTION
Python 3.7 support was deprecated with [1.33.0 (November 2023)](https://github.com/adrienverge/yamllint/blob/v1.35.1/CHANGELOG.rst) and the current version is 1.35.0.

Not sure if there are any performance gains waiting for us, but hopefully this keeps the action up to date with the upstream `yamllint` releases.

